### PR TITLE
OP1-03: Adding the Custom Config Form for the Salutation.

### DIFF
--- a/modules/custom/firstmodule/firstmodule.routing.yml
+++ b/modules/custom/firstmodule/firstmodule.routing.yml
@@ -10,6 +10,7 @@ firstmodule.greeting_form:
   defaults:
     _form: Drupal\firstmodule\Form\SalutationConfigurationForm
     _title: 'Custom Salutation configuration'
+  # limiting the access for this page only for administrators
   requirements:
     _permission: 'administer site configuration'
  # Option for applying the admin_theme for the Config Form for the above 'salutation-configuration' route

--- a/modules/custom/firstmodule/firstmodule.routing.yml
+++ b/modules/custom/firstmodule/firstmodule.routing.yml
@@ -12,3 +12,7 @@ firstmodule.greeting_form:
     _title: 'Custom Salutation configuration'
   requirements:
     _permission: 'administer site configuration'
+ # Option for applying the admin_theme for the Config Form for the above 'salutation-configuration' route
+ # just adding it as a placeholder for future purpose
+ #options:
+ #   _admin_route: TRUE

--- a/modules/custom/firstmodule/firstmodule.routing.yml
+++ b/modules/custom/firstmodule/firstmodule.routing.yml
@@ -5,3 +5,10 @@ firstmodule.hello:
     _title: 'Our First Custom Route'
   requirements:
     _permission: 'access_content'
+firstmodule.greeting_form:
+  path: '/admin/config/salutation-configuration'
+  defaults:
+    _form: Drupal\firstmodule\Form\SalutationConfigurationForm
+    _title: 'Custom Salutation configuration'
+  requirements:
+    _permission: 'administer site configuration'

--- a/modules/custom/firstmodule/src/Form/SalutationConfigurationForm.php
+++ b/modules/custom/firstmodule/src/Form/SalutationConfigurationForm.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Drupal\firstmodule\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Configuration form definition for the custom salutation message.
+ */
+class SalutationConfigurationForm extends ConfigFormBase {
+
+  /**
+   * {@inheritdoc}
+   * Defining the getEditableConfigNames() method with the unique machine-readable name
+   * so that this config can be editable going forward
+   */
+  protected function getEditableConfigNames() {
+    return ['firstmodule.custom_salutation'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'salutation_configuration_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config('firstmodule.custom_salutation');
+
+    $form['salutation'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Salutation'),
+      '#description' => $this->t('Please provide the custom salutation message you want to show.'),
+      '#default_value' => $config->get('salutation'),
+    ];
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $this->config('firstmodule.custom_salutation')
+      ->set('salutation', $form_state->getValue('salutation'))
+      ->save();
+
+    parent::submitForm($form, $form_state);
+  }
+
+}


### PR DESCRIPTION
**Scenario**: We need to have a custom Config Form for the 'Salutation' message and only 'administrator' should have access to set the message.

This PR has dependency on https://github.com/prudhviphp1/d10-development/pull/8

We solved the above scenario by adding the following stuff:

- Added '/admin/config/salutation-configuration' in the routing.yml file
- Added new 'SalutationConfigurationForm' and defined the business logic over there.
