### PR TITLE
OP1-04: Adding the custom submit_handler method for Salutation Configuration_form.

### DIFF
--- a/modules/custom/firstmodule/firstmodule.module
+++ b/modules/custom/firstmodule/firstmodule.module
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Form\FormStateInterface;
 
 /**
  * DocBlock comments/message
@@ -24,4 +25,14 @@ function firstmodule_help($route_name, RouteMatchInterface $route_match)
 
     default:
   }
+}
+
+/**
+ * DocBlock message
+ * Implements hook_form_FORM_ID_alter().
+ * Adding the custom submit_handler which needs to applied for the salutation_configuration_form
+ */
+ function my_module_form_salutation_configuration_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
+  // Perform alterations.
+   $form['#submit'][] = 'firstmodule_salutation_configuration_form_submit';
 }

--- a/modules/custom/firstmodule/src/Form/SalutationConfigurationForm.php
+++ b/modules/custom/firstmodule/src/Form/SalutationConfigurationForm.php
@@ -54,3 +54,13 @@ class SalutationConfigurationForm extends ConfigFormBase {
   }
 
 }
+
+/**
+* Defining the Custom submit handler for the form_salutation_configuration form.
+*
+* @param $form
+* @param \Drupal\Core\Form\FormStateInterface $form_state
+*/
+function firstmodule_salutation_configuration_form_submit(&$form, FormStateInterface $form_state) {
+// Do something when the form is submitted.
+}


### PR DESCRIPTION
**Scenario**: We need to alter the Salutation Configuration form to alter the submit handler.

This PR is acting as a placeholder for adding the business logic & has dependency on https://github.com/prudhviphp1/d10-development/pull/13

We solved the above scenario by adding the following stuff:

- Added the hook_form_FORM_ID_alter method to change the callback method for 'submit' variable in salutation_config_form in .module file
- Defined the custom submit handler callback method defined in the above hook