### PR TITLE
OP1-05: Possible way for creating & reusing the pre-existing form.

### DIFF
--- a/modules/custom/firstmodule/src/Controller/HelloDrupalController.php
+++ b/modules/custom/firstmodule/src/Controller/HelloDrupalController.php
@@ -51,6 +51,11 @@ class HelloDrupalController extends ControllerBase {
     return[
       '#markup' => $this->t('Hello Drupal Custom Route'),
     ];
+
+    // Adding this for rendering the form programatically without writing all the business logic
+    // & want to use pre-existing form in the site
+    // $builder = \Drupal::formBuilder();
+    // $form = $builder->getForm('Drupal\hello_world\Form\SalutationConfigurationForm');
   }
 
 


### PR DESCRIPTION
**Scenario**: We need to have a form shown up on one of the page where we don't want to use any of the route mapping to the form approach.This PR has a dependency on https://github.com/prudhviphp1/d10-development/pull/14

We solved the above scenario by adding the following stuff.
- Added the formBuilder drupal core service statistically as a placeholder(i.e I believe adding the service statistically may not be an ideal way)