### PR TITLE
OP1-11: Adding the 'hook_theme_suggestions_HOOK' feature(C-4).

### DIFF
--- a/modules/custom/firstmodule/firstmodule.module
+++ b/modules/custom/firstmodule/firstmodule.module
@@ -68,7 +68,7 @@ function firstmodule_theme($existing, $type, $theme, $path) {
   /**
    * Implements hook_theme_suggestions_HOOK().
    */
-  function hello_world_theme_suggestions_firstmodule_salutation($variables) {
+  function firstmodule_theme_suggestions_firstmodule_salutation($variables) {
     $suggestions = [];
 
     if ($variables['overridden'] === TRUE) {

--- a/modules/custom/firstmodule/firstmodule.module
+++ b/modules/custom/firstmodule/firstmodule.module
@@ -64,4 +64,17 @@ function firstmodule_theme($existing, $type, $theme, $path) {
       'class' => ['salutation'],
     ];
   }
+
+  /**
+   * Implements hook_theme_suggestions_HOOK().
+   */
+  function hello_world_theme_suggestions_firstmodule_salutation($variables) {
+    $suggestions = [];
+
+    if ($variables['overridden'] === TRUE) {
+      $suggestions[] = 'firstmodule_salutation__overridden';
+    }
+
+    return $suggestions;
+  }
 }

--- a/modules/custom/firstmodule/firstmodule.module
+++ b/modules/custom/firstmodule/firstmodule.module
@@ -67,6 +67,8 @@ function firstmodule_theme($existing, $type, $theme, $path) {
 
   /**
    * Implements hook_theme_suggestions_HOOK().
+   *
+   * Adding the alternate twig file if the overridden is set to TRUE
    */
   function firstmodule_theme_suggestions_firstmodule_salutation($variables) {
     $suggestions = [];

--- a/modules/custom/firstmodule/templates/firstmodule-salutation--overridden.html.twig
+++ b/modules/custom/firstmodule/templates/firstmodule-salutation--overridden.html.twig
@@ -1,0 +1,6 @@
+<div {{ attributes }}>
+  {{ salutation }}
+  {% if target %}
+    <span class="salutation—target">{{ target }}</span>
+  {% endif %}
+</div>


### PR DESCRIPTION
**Scenario**: We need to have the suggestions to the theme to use the alternate twig file when the 'overridden' is set to TRUE

We solved the above scenario by adding the following stuff:

- Added 'hook_theme_suggestion_HOOK'  to our custom module  .module file.
- added the new alternate twig template file