### PR TITLE
OP1-12: Adding the 'config_override' feature(C-6).

### DIFF
--- a/modules/custom/firstmodule/firstmodule.services.yml
+++ b/modules/custom/firstmodule/firstmodule.services.yml
@@ -5,12 +5,14 @@ services:
     #  - { name: tag_name }
     arguments: ['@config.factory', '@event_dispatcher']
 
+  # creating the service for 'event_subscriber' feature
   firstmodule.redirect_subscriber:
     class: Drupal\firstmodule\EventSubscriber\FirstModuleRedirectSubscriber
     arguments: [ '@current_user', '@current_route_match' ]
     tags:
       - { name: event_subscriber }
 
+  # creating the service for 'Config_override' feature
   firstmodule.config_overrider:
     class: Drupal\  firstmodule\FirstModuleConfigOverrides
     tags:

--- a/modules/custom/firstmodule/firstmodule.services.yml
+++ b/modules/custom/firstmodule/firstmodule.services.yml
@@ -14,6 +14,6 @@ services:
 
   # creating the service for 'Config_override' feature
   firstmodule.config_overrider:
-    class: Drupal\  firstmodule\FirstModuleConfigOverrides
+    class: Drupal\firstmodule\FirstModuleConfigOverrides
     tags:
       - { name: config.factory.override, priority: 5 }

--- a/modules/custom/firstmodule/firstmodule.services.yml
+++ b/modules/custom/firstmodule/firstmodule.services.yml
@@ -10,3 +10,8 @@ services:
     arguments: [ '@current_user', '@current_route_match' ]
     tags:
       - { name: event_subscriber }
+
+  firstmodule.config_overrider:
+    class: Drupal\  firstmodule\FirstModuleConfigOverrides
+    tags:
+      - { name: config.factory.override, priority: 5 }

--- a/modules/custom/firstmodule/src/FirstModuleConfigOverrides.php
+++ b/modules/custom/firstmodule/src/FirstModuleConfigOverrides.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Drupal\firstmodule;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Config\ConfigFactoryOverrideInterface;
+use Drupal\Core\Config\StorageInterface;
+
+/**
+ * Overrides configuration for the FirstModule module.
+ */
+class FirstModuleConfigOverrides implements ConfigFactoryOverrideInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function loadOverrides($names) {
+    $overrides = [];
+    if (in_array('system.maintenance', $names)) {
+      $overrides['system.maintenance'] = ['message' => 'Our own message for the site maintenance mode.'];
+    }
+
+    return $overrides;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheSuffix() {
+    return 'FirstModuleConfigOverrider';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function createConfigObject($name, $collection = StorageInterface::DEFAULT_COLLECTION) {
+    return NULL;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheableMetadata($name) {
+    return new CacheableMetadata();
+  }
+
+}

--- a/modules/custom/firstmodule/src/FirstModuleConfigOverrides.php
+++ b/modules/custom/firstmodule/src/FirstModuleConfigOverrides.php
@@ -7,12 +7,14 @@ use Drupal\Core\Config\ConfigFactoryOverrideInterface;
 use Drupal\Core\Config\StorageInterface;
 
 /**
- * Overrides configuration for the FirstModule module.
+ * Overrides the core configuration in the FirstModule custom module.
  */
 class FirstModuleConfigOverrides implements ConfigFactoryOverrideInterface {
 
   /**
    * {@inheritdoc}
+   *
+   * Returns config overrides.
    */
   public function loadOverrides($names) {
     $overrides = [];
@@ -25,6 +27,8 @@ class FirstModuleConfigOverrides implements ConfigFactoryOverrideInterface {
 
   /**
    * {@inheritdoc}
+   *
+   *  Defining the string to append to the configuration static cache name.
    */
   public function getCacheSuffix() {
     return 'FirstModuleConfigOverrider';
@@ -32,6 +36,8 @@ class FirstModuleConfigOverrides implements ConfigFactoryOverrideInterface {
 
   /**
    * {@inheritdoc}
+   *
+   * Creates a configuration object for use during install and synchronization.
    */
   public function createConfigObject($name, $collection = StorageInterface::DEFAULT_COLLECTION) {
     return NULL;
@@ -39,6 +45,8 @@ class FirstModuleConfigOverrides implements ConfigFactoryOverrideInterface {
 
   /**
    * {@inheritdoc}
+   *
+   * Gets the cacheability metadata associated with the config factory override.
    */
   public function getCacheableMetadata($name) {
     return new CacheableMetadata();


### PR DESCRIPTION
**Scenario**: We need to override the core configuration of 'system.maintenance' to our custom message with invalidating the pre-existing cache of the configuration in the site.

We solved the above scenario by adding the following stuff:

- Created the custom service '_firstmodule.config_overrider_' 
- Created the new 'CustomConfigOverrides' file & mapped it to the above custom service.
- In the above 'CustomConfigOverrides' file we have defined the business logic of altering the 'system.maintenance' to our custom message & invalidating the pre-existing config cache in their respective methods