### PR TITLE
OP1-17: Creating the Product Entity by implementing ProductInterface(C-7)

### DIFF
--- a/modules/custom/products/src/Entity/Product.php
+++ b/modules/custom/products/src/Entity/Product.php
@@ -1,0 +1,209 @@
+<?php
+
+namespace Drupal\products\Entity;
+
+use Drupal\Core\Entity\ContentEntityBase;
+use Drupal\Core\Entity\EntityChangedTrait;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
+
+/**
+ * Defines the Product entity.
+ *
+ * Declaring the Product Entity with annotations, inheriting a lot from core Drupal Entity API
+ *
+ * @ContentEntityType(
+ *   id = "product",
+ *   label = @Translation("Product"),
+ *   bundle_label = @Translation("Product type"),
+ *   handlers = {
+ *     "view_builder" = "Drupal\Core\Entity\EntityViewBuilder",
+ *     "list_builder" = "Drupal\products\ProductListBuilder",
+ *
+ *     "form" = {
+ *       "default" = "Drupal\products\Form\ProductForm",
+ *       "add" = "Drupal\products\Form\ProductForm",
+ *       "edit" = "Drupal\products\Form\ProductForm",
+ *       "delete" = "Drupal\Core\Entity\ContentEntityDeleteForm",
+ *     },
+ *    "route_provider" = {
+ *      "html" = "Drupal\Core\Entity\Routing\AdminHtmlRouteProvider"
+ *    }
+ *   },
+ *   base_table = "product",
+ *   admin_permission = "administer site configuration",
+ *   entity_keys = {
+ *     "id" = "id",
+ *     "label" = "name",
+ *     "uuid" = "uuid",
+ *     "bundle" = "type"
+ *   },
+ *   links = {
+ *     "canonical" = "/admin/structure/product/{product}",
+ *     "add-form" = "/admin/structure/product/add/{product_type}",
+ *     "add-page" = "/admin/structure/product/add",
+ *     "edit-form" = "/admin/structure/product/{product}/edit",
+ *     "delete-form" = "/admin/structure/product/{product}/delete",
+ *     "collection" = "/admin/structure/product",
+ *   },
+ *   bundle_entity_type = "product_type",
+ *   field_ui_base_route = "entity.product_type.edit_form"
+ * )
+ */
+class Product extends ContentEntityBase implements ProductInterface {
+
+  use EntityChangedTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getName() {
+    return $this->get('name')->value;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setName($name) {
+    $this->set('name', $name);
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getProductNumber() {
+    return $this->get('number')->value;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setProductNumber($number) {
+    $this->set('number', $number);
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRemoteId() {
+    return $this->get('remote_id')->value;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setRemoteId($id) {
+    $this->set('remote_id', $id);
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getSource() {
+    return $this->get('source')->value;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setSource($source) {
+    $this->set('source', $source);
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCreatedTime() {
+    return $this->get('created')->value;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setCreatedTime($timestamp) {
+    $this->set('created', $timestamp);
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * Defining the baseFieldDefinitions method & then overriding the few functionality
+   * for fields from the parent
+   */
+  public static function baseFieldDefinitions(EntityTypeInterface $entity_type) {
+    $fields = parent::baseFieldDefinitions($entity_type);
+
+    $fields['name'] = BaseFieldDefinition::create('string')
+      ->setLabel(t('Name'))
+      ->setDescription(t('The name of the Product.'))
+      ->setSettings([
+        'max_length' => 255,
+        'text_processing' => 0,
+      ])
+      ->setDefaultValue('')
+      ->setDisplayOptions('view', [
+        'label' => 'hidden',
+        'type' => 'string',
+        'weight' => -4,
+      ])
+      ->setDisplayOptions('form', [
+        'type' => 'string_textfield',
+        'weight' => -4,
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['number'] = BaseFieldDefinition::create('integer')
+      ->setLabel(t('Number'))
+      ->setDescription(t('The Product number.'))
+      ->setSettings([
+        'min' => 1,
+        'max' => 10000,
+      ])
+      ->setDisplayOptions('view', [
+        'label' => 'above',
+        'type' => 'number_unformatted',
+        'weight' => -4,
+      ])
+      ->setDisplayOptions('form', [
+        'type' => 'number',
+        'weight' => -4,
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['remote_id'] = BaseFieldDefinition::create('string')
+      ->setLabel(t('Remote ID'))
+      ->setDescription(t('The remote ID of the Product.'))
+      ->setSettings([
+        'max_length' => 255,
+        'text_processing' => 0,
+      ])
+      ->setDefaultValue('');
+
+    $fields['source'] = BaseFieldDefinition::create('string')
+      ->setLabel(t('Source'))
+      ->setDescription(t('The source of the Product.'))
+      ->setSettings([
+        'max_length' => 255,
+        'text_processing' => 0,
+      ])
+      ->setDefaultValue('');
+
+    $fields['created'] = BaseFieldDefinition::create('created')
+      ->setLabel(t('Created'))
+      ->setDescription(t('The time that the entity was created.'));
+
+    $fields['changed'] = BaseFieldDefinition::create('changed')
+      ->setLabel(t('Changed'))
+      ->setDescription(t('The time that the entity was last edited.'));
+
+    return $fields;
+  }
+
+}

--- a/modules/custom/products/src/Entity/Product.php
+++ b/modules/custom/products/src/Entity/Product.php
@@ -11,6 +11,9 @@ use Drupal\Core\Field\BaseFieldDefinition;
  * Defines the Product entity.
  *
  * Declaring the Product Entity with annotations, inheriting a lot from core Drupal Entity API
+ * with the admin permission
+ *
+ * Defining Product Entity fields with handlers, form, route_provider, entity_keys & links
  *
  * @ContentEntityType(
  *   id = "product",


### PR DESCRIPTION
**Scenario:** Need to have the Product Entity where we can get & set the information data for the product.

We solved the above scenario with following stuff:

- Created Product Entity implementing ProductInterface
- Using getter & setter methods to get & set the information
- Using baseFieldDefinitions to set the Label, DisplayOptions, Configurable options for every custom fields in entity