### PR TITLE
OP1-18: Creating the ProductForm by extending ContentEntityForm(C-7)

### DIFF
--- a/modules/custom/products/src/Form/ProductForm.php
+++ b/modules/custom/products/src/Form/ProductForm.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\products\Form;
+
+use Drupal\Core\Entity\ContentEntityForm;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Form for creating/editing the custom Product entities
+ *
+ * As per the annotations defined in Entity/Product for forms defining the ProductForm
+ */
+class ProductForm extends ContentEntityForm {
+
+  /**
+   * {@inheritdoc}
+   *
+   * Altering the save() method functionality from the parent
+   */
+  public function save(array $form, FormStateInterface $form_state) {
+    $entity = $this->entity;
+
+    $status = parent::save($form, $form_state);
+
+    switch ($status) {
+      case SAVED_NEW:
+        $this->messenger()->addMessage($this->t('Created the %label Product.', [
+          '%label' => $entity->label(),
+        ]));
+        break;
+
+      default:
+        $this->messenger()->addMessage($this->t('Saved the %label Product.', [
+          '%label' => $entity->label(),
+        ]));
+    }
+    $form_state->setRedirect('entity.product.canonical', ['product' => $entity->id()]);
+  }
+
+}


### PR DESCRIPTION
**Scenario:** We need to have a Form for creating the product information.

We solved the above scenario with the following stuff:

- Created ProductForm by extending from ContentEntityForm
- Altered the save() method functionality