### PR TITLE
OP1-18: Running the phpcs & phpcbf to align with php coding standards

### DIFF
--- a/modules/custom/products/src/Entity/Product.php
+++ b/modules/custom/products/src/Entity/Product.php
@@ -53,160 +53,188 @@ use Drupal\Core\Field\BaseFieldDefinition;
  *   field_ui_base_route = "entity.product_type.edit_form"
  * )
  */
-class Product extends ContentEntityBase implements ProductInterface {
+class Product extends ContentEntityBase implements ProductInterface
+{
 
-  use EntityChangedTrait;
+    use EntityChangedTrait;
 
-  /**
-   * {@inheritdoc}
-   */
-  public function getName() {
-    return $this->get('name')->value;
-  }
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return $this->get('name')->value;
+    }
 
-  /**
-   * {@inheritdoc}
-   */
-  public function setName($name) {
-    $this->set('name', $name);
-    return $this;
-  }
+    /**
+     * {@inheritdoc}
+     */
+    public function setName($name)
+    {
+        $this->set('name', $name);
+        return $this;
+    }
 
-  /**
-   * {@inheritdoc}
-   */
-  public function getProductNumber() {
-    return $this->get('number')->value;
-  }
+    /**
+     * {@inheritdoc}
+     */
+    public function getProductNumber()
+    {
+        return $this->get('number')->value;
+    }
 
-  /**
-   * {@inheritdoc}
-   */
-  public function setProductNumber($number) {
-    $this->set('number', $number);
-    return $this;
-  }
+    /**
+     * {@inheritdoc}
+     */
+    public function setProductNumber($number)
+    {
+        $this->set('number', $number);
+        return $this;
+    }
 
-  /**
-   * {@inheritdoc}
-   */
-  public function getRemoteId() {
-    return $this->get('remote_id')->value;
-  }
+    /**
+     * {@inheritdoc}
+     */
+    public function getRemoteId()
+    {
+        return $this->get('remote_id')->value;
+    }
 
-  /**
-   * {@inheritdoc}
-   */
-  public function setRemoteId($id) {
-    $this->set('remote_id', $id);
-    return $this;
-  }
+    /**
+     * {@inheritdoc}
+     */
+    public function setRemoteId($id)
+    {
+        $this->set('remote_id', $id);
+        return $this;
+    }
 
-  /**
-   * {@inheritdoc}
-   */
-  public function getSource() {
-    return $this->get('source')->value;
-  }
+    /**
+     * {@inheritdoc}
+     */
+    public function getSource()
+    {
+        return $this->get('source')->value;
+    }
 
-  /**
-   * {@inheritdoc}
-   */
-  public function setSource($source) {
-    $this->set('source', $source);
-    return $this;
-  }
+    /**
+     * {@inheritdoc}
+     */
+    public function setSource($source)
+    {
+        $this->set('source', $source);
+        return $this;
+    }
 
-  /**
-   * {@inheritdoc}
-   */
-  public function getCreatedTime() {
-    return $this->get('created')->value;
-  }
+    /**
+     * {@inheritdoc}
+     */
+    public function getCreatedTime()
+    {
+        return $this->get('created')->value;
+    }
 
-  /**
-   * {@inheritdoc}
-   */
-  public function setCreatedTime($timestamp) {
-    $this->set('created', $timestamp);
-    return $this;
-  }
+    /**
+     * {@inheritdoc}
+     */
+    public function setCreatedTime($timestamp)
+    {
+        $this->set('created', $timestamp);
+        return $this;
+    }
 
-  /**
-   * {@inheritdoc}
-   *
-   * Defining the baseFieldDefinitions method & then overriding the few functionality
-   * for fields from the parent
-   */
-  public static function baseFieldDefinitions(EntityTypeInterface $entity_type) {
-    $fields = parent::baseFieldDefinitions($entity_type);
+    /**
+     * {@inheritdoc}
+     *
+     * Defining the baseFieldDefinitions method & then overriding the few functionality
+     * for fields from the parent
+     */
+    public static function baseFieldDefinitions(EntityTypeInterface $entity_type)
+    {
+        $fields = parent::baseFieldDefinitions($entity_type);
 
-    $fields['name'] = BaseFieldDefinition::create('string')
-      ->setLabel(t('Name'))
-      ->setDescription(t('The name of the Product.'))
-      ->setSettings([
-        'max_length' => 255,
-        'text_processing' => 0,
-      ])
-      ->setDefaultValue('')
-      ->setDisplayOptions('view', [
-        'label' => 'hidden',
-        'type' => 'string',
-        'weight' => -4,
-      ])
-      ->setDisplayOptions('form', [
-        'type' => 'string_textfield',
-        'weight' => -4,
-      ])
-      ->setDisplayConfigurable('form', TRUE)
-      ->setDisplayConfigurable('view', TRUE);
+        $fields['name'] = BaseFieldDefinition::create('string')
+            ->setLabel(t('Name'))
+            ->setDescription(t('The name of the Product.'))
+            ->setSettings(
+                [
+                'max_length' => 255,
+                'text_processing' => 0,
+                ]
+            )
+            ->setDefaultValue('')
+            ->setDisplayOptions(
+                'view', [
+                'label' => 'hidden',
+                'type' => 'string',
+                'weight' => -4,
+                ]
+            )
+            ->setDisplayOptions(
+                'form', [
+                'type' => 'string_textfield',
+                'weight' => -4,
+                ]
+            )
+            ->setDisplayConfigurable('form', true)
+            ->setDisplayConfigurable('view', true);
 
-    $fields['number'] = BaseFieldDefinition::create('integer')
-      ->setLabel(t('Number'))
-      ->setDescription(t('The Product number.'))
-      ->setSettings([
-        'min' => 1,
-        'max' => 10000,
-      ])
-      ->setDisplayOptions('view', [
-        'label' => 'above',
-        'type' => 'number_unformatted',
-        'weight' => -4,
-      ])
-      ->setDisplayOptions('form', [
-        'type' => 'number',
-        'weight' => -4,
-      ])
-      ->setDisplayConfigurable('form', TRUE)
-      ->setDisplayConfigurable('view', TRUE);
+        $fields['number'] = BaseFieldDefinition::create('integer')
+            ->setLabel(t('Number'))
+            ->setDescription(t('The Product number.'))
+            ->setSettings(
+                [
+                'min' => 1,
+                'max' => 10000,
+                ]
+            )
+            ->setDisplayOptions(
+                'view', [
+                'label' => 'above',
+                'type' => 'number_unformatted',
+                'weight' => -4,
+                ]
+            )
+            ->setDisplayOptions(
+                'form', [
+                'type' => 'number',
+                'weight' => -4,
+                ]
+            )
+            ->setDisplayConfigurable('form', true)
+            ->setDisplayConfigurable('view', true);
 
-    $fields['remote_id'] = BaseFieldDefinition::create('string')
-      ->setLabel(t('Remote ID'))
-      ->setDescription(t('The remote ID of the Product.'))
-      ->setSettings([
-        'max_length' => 255,
-        'text_processing' => 0,
-      ])
-      ->setDefaultValue('');
+        $fields['remote_id'] = BaseFieldDefinition::create('string')
+            ->setLabel(t('Remote ID'))
+            ->setDescription(t('The remote ID of the Product.'))
+            ->setSettings(
+                [
+                'max_length' => 255,
+                'text_processing' => 0,
+                ]
+            )
+            ->setDefaultValue('');
 
-    $fields['source'] = BaseFieldDefinition::create('string')
-      ->setLabel(t('Source'))
-      ->setDescription(t('The source of the Product.'))
-      ->setSettings([
-        'max_length' => 255,
-        'text_processing' => 0,
-      ])
-      ->setDefaultValue('');
+        $fields['source'] = BaseFieldDefinition::create('string')
+            ->setLabel(t('Source'))
+            ->setDescription(t('The source of the Product.'))
+            ->setSettings(
+                [
+                'max_length' => 255,
+                'text_processing' => 0,
+                ]
+            )
+            ->setDefaultValue('');
 
-    $fields['created'] = BaseFieldDefinition::create('created')
-      ->setLabel(t('Created'))
-      ->setDescription(t('The time that the entity was created.'));
+        $fields['created'] = BaseFieldDefinition::create('created')
+            ->setLabel(t('Created'))
+            ->setDescription(t('The time that the entity was created.'));
 
-    $fields['changed'] = BaseFieldDefinition::create('changed')
-      ->setLabel(t('Changed'))
-      ->setDescription(t('The time that the entity was last edited.'));
+        $fields['changed'] = BaseFieldDefinition::create('changed')
+            ->setLabel(t('Changed'))
+            ->setDescription(t('The time that the entity was last edited.'));
 
-    return $fields;
-  }
+        return $fields;
+    }
 
 }

--- a/modules/custom/products/src/Entity/ProductInterface.php
+++ b/modules/custom/products/src/Entity/ProductInterface.php
@@ -10,101 +10,102 @@ use Drupal\Core\Entity\EntityChangedInterface;
  *
  * Defining all the methods in the Interface for storing the Product Entity Information
  */
-interface ProductInterface extends ContentEntityInterface, EntityChangedInterface {
+interface ProductInterface extends ContentEntityInterface, EntityChangedInterface
+{
 
-  /**
-   * Gets the Product name.
-   *
-   * @return string
-   *   The name.
-   */
-  public function getName();
+    /**
+     * Gets the Product name.
+     *
+     * @return string
+     *   The name.
+     */
+    public function getName();
 
-  /**
-   * Sets the Product name.
-   *
-   * @param string $name
-   *   The name.
-   *
-   * @return \Drupal\products\Entity\ProductInterface
-   *   The called Product entity.
-   */
-  public function setName($name);
+    /**
+     * Sets the Product name.
+     *
+     * @param string $name
+     *   The name.
+     *
+     * @return \Drupal\products\Entity\ProductInterface
+     *   The called Product entity.
+     */
+    public function setName($name);
 
-  /**
-   * Gets the Product number.
-   *
-   * @return int
-   *   The product number.
-   */
-  public function getProductNumber();
+    /**
+     * Gets the Product number.
+     *
+     * @return int
+     *   The product number.
+     */
+    public function getProductNumber();
 
-  /**
-   * Sets the Product number.
-   *
-   * @param int $number
-   *   The product number.
-   *
-   * @return \Drupal\products\Entity\ProductInterface
-   *   The called Product entity.
-   */
-  public function setProductNumber($number);
+    /**
+     * Sets the Product number.
+     *
+     * @param int $number
+     *   The product number.
+     *
+     * @return \Drupal\products\Entity\ProductInterface
+     *   The called Product entity.
+     */
+    public function setProductNumber($number);
 
-  /**
-   * Gets the Product remote ID.
-   *
-   * @return string
-   *   The product remote ID.
-   */
-  public function getRemoteId();
+    /**
+     * Gets the Product remote ID.
+     *
+     * @return string
+     *   The product remote ID.
+     */
+    public function getRemoteId();
 
-  /**
-   * Sets the Product remote ID.
-   *
-   * @param string $id
-   *   The product remote ID.
-   *
-   * @return \Drupal\products\Entity\ProductInterface
-   *   The called Product entity.
-   */
-  public function setRemoteId($id);
+    /**
+     * Sets the Product remote ID.
+     *
+     * @param string $id
+     *   The product remote ID.
+     *
+     * @return \Drupal\products\Entity\ProductInterface
+     *   The called Product entity.
+     */
+    public function setRemoteId($id);
 
-  /**
-   * Gets the Product source.
-   *
-   * @return string
-   *   The product source.
-   */
-  public function getSource();
+    /**
+     * Gets the Product source.
+     *
+     * @return string
+     *   The product source.
+     */
+    public function getSource();
 
-  /**
-   * Sets the Product source.
-   *
-   * @param string $source
-   *   The product source.
-   *
-   * @return \Drupal\products\Entity\ProductInterface
-   *   The called Product entity.
-   */
-  public function setSource($source);
+    /**
+     * Sets the Product source.
+     *
+     * @param string $source
+     *   The product source.
+     *
+     * @return \Drupal\products\Entity\ProductInterface
+     *   The called Product entity.
+     */
+    public function setSource($source);
 
-  /**
-   * Gets the Product creation timestamp.
-   *
-   * @return int
-   *   The created timestamp.
-   */
-  public function getCreatedTime();
+    /**
+     * Gets the Product creation timestamp.
+     *
+     * @return int
+     *   The created timestamp.
+     */
+    public function getCreatedTime();
 
-  /**
-   * Sets the Product creation timestamp.
-   *
-   * @param int $timestamp
-   *   The created timestamp.
-   *
-   * @return \Drupal\products\Entity\ProductInterface
-   *   The called Product entity.
-   */
-  public function setCreatedTime($timestamp);
+    /**
+     * Sets the Product creation timestamp.
+     *
+     * @param int $timestamp
+     *   The created timestamp.
+     *
+     * @return \Drupal\products\Entity\ProductInterface
+     *   The called Product entity.
+     */
+    public function setCreatedTime($timestamp);
 
 }

--- a/modules/custom/products/src/Form/ProductForm.php
+++ b/modules/custom/products/src/Form/ProductForm.php
@@ -10,31 +10,41 @@ use Drupal\Core\Form\FormStateInterface;
  *
  * As per the annotations defined in Entity/Product for forms defining the ProductForm
  */
-class ProductForm extends ContentEntityForm {
+class ProductForm extends ContentEntityForm
+{
 
-  /**
-   * {@inheritdoc}
-   *
-   * Altering the save() method functionality from the parent
-   */
-  public function save(array $form, FormStateInterface $form_state) {
-    $entity = $this->entity;
+    /**
+     * {@inheritdoc}
+     *
+     * Altering the save() method functionality from the parent
+     */
+    public function save(array $form, FormStateInterface $form_state)
+    {
+        $entity = $this->entity;
 
-    $status = parent::save($form, $form_state);
+        $status = parent::save($form, $form_state);
 
-    switch ($status) {
-      case SAVED_NEW:
-        $this->messenger()->addMessage($this->t('Created the %label Product.', [
-          '%label' => $entity->label(),
-        ]));
-        break;
+        switch ($status) {
+        case SAVED_NEW:
+            $this->messenger()->addMessage(
+                $this->t(
+                    'Created the %label Product.', [
+                    '%label' => $entity->label(),
+                    ]
+                )
+            );
+            break;
 
-      default:
-        $this->messenger()->addMessage($this->t('Saved the %label Product.', [
-          '%label' => $entity->label(),
-        ]));
+        default:
+            $this->messenger()->addMessage(
+                $this->t(
+                    'Saved the %label Product.', [
+                    '%label' => $entity->label(),
+                    ]
+                )
+            );
+        }
+        $form_state->setRedirect('entity.product.canonical', ['product' => $entity->id()]);
     }
-    $form_state->setRedirect('entity.product.canonical', ['product' => $entity->id()]);
-  }
 
 }


### PR DESCRIPTION
Scenario: Need to make the code align with PHP coding standards.

We have solved the above scenario with the following stuff.
run  `lando php vendor/bin/phpcs --cache modules/custom/products` &`lando php vendor/bin/phpcbf --cache modules/custom/products`