### PR TITLE
OP1-21c: Adding composer.json for custom drush command

### DIFF
--- a/modules/custom/products/composer.json
+++ b/modules/custom/products/composer.json
@@ -1,0 +1,17 @@
+{
+    "name": "drupal/products",
+    "description": "Importing products like a boss.",
+    "type": "drupal-module",
+    "autoload": {
+        "psr-4": {
+            "Drupal\\products\\": "src/"
+        }
+    },
+    "extra": {
+        "drush": {
+            "services": {
+                "drush.services.yml": "^10"
+            }
+        }
+    }
+}

--- a/modules/custom/products/composer.json
+++ b/modules/custom/products/composer.json
@@ -1,4 +1,7 @@
 {
+    // Placeholder for adding any dependencies that are required specifically
+    // for our custom drush command and making it compatible with different
+    // versions of drush.
     "name": "drupal/products",
     "description": "Importing products like a boss.",
     "type": "drupal-module",


### PR DESCRIPTION
This PR has dependency on #46.
**Scenario:** We need to have drush version 10 compatibility for custom drush command.

We solved the above scenario with the following stuff:

- Adding composer.json file for making drush version version 10 compability.
- Can also add additional dependencies if anything is required for drush command.