### PR TITLE
OP1-22: Adding custom sports module and defining metadata of the module(C-8).

### DIFF
--- a/modules/custom/sports/sports.info.yml
+++ b/modules/custom/sports/sports.info.yml
@@ -1,0 +1,4 @@
+name: sports
+description: Custom Sports Module
+core_version_requirement: ^10
+type: module

--- a/modules/custom/sports/sports.install
+++ b/modules/custom/sports/sports.install
@@ -72,3 +72,18 @@ function sports_schema() {
   return $schema;
 }
 
+/**
+ * Using hook_update_N to update the database
+ *
+ * Adds the "location" field to the teams table.
+ */
+function sports_update_10001(&$sandbox) {
+  $field = [
+    'description' => 'The team location.',
+    'type' => 'varchar',
+    'length' => 255,
+  ];
+  $schema = \Drupal::database()->schema();
+  $schema->addField('teams', 'location', $field);
+}
+

--- a/modules/custom/sports/sports.install
+++ b/modules/custom/sports/sports.install
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * @file
+ * The Sports module install file.
+ */
+
+/**
+ * Implements hook_schema().
+ */
+function sports_schema() {
+  $schema = [];
+
+  $schema['teams'] = [
+    'description' => 'The table that holds team data.',
+    'fields' => [
+      'id' => [
+        'description' => 'The primary identifier.',
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ],
+      'name' => [
+        'description' => 'The team name.',
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+      ],
+      'description' => [
+        'description' => 'The team description.',
+        'type' => 'text',
+        'size' => 'normal',
+      ],
+      'location' => [
+        'description' => 'The team location.',
+        'type' => 'varchar',
+        'length' => 255,
+      ],
+    ],
+    'primary key' => ['id'],
+  ];
+
+  $schema['players'] = [
+    'description' => 'The table that holds player data.',
+    'fields' => [
+      'id' => [
+        'description' => 'The primary identifier.',
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ],
+      'team_id' => [
+        'description' => 'The ID of the team it belongs to.',
+        'type' => 'int',
+        'unsigned' => TRUE,
+      ],
+      'name' => [
+        'description' => 'The player name.',
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+      ],
+      'data' => [
+        'description' => 'Arbitrary data about the player.',
+        'type' => 'blob',
+        'size' => 'big',
+      ],
+    ],
+    'primary key' => ['id'],
+  ];
+
+  return $schema;
+}
+


### PR DESCRIPTION
**Scenario:** We need a sports table with the teams, players & location in the same table with the pager functionality.

We have solved the above scenario with the following stuff:

- Created a new 'sports' custom module
- defined the fields data in hook_schema for database table
- added 'location' field to the db table through hook_update_N
- added the Controller for '/players' route.