### PR TITLE
OP1-24: Adding the custom 'user_types' module(C-10)

### DIFF
--- a/modules/custom/user_types/user_types.info.yml
+++ b/modules/custom/user_types/user_types.info.yml
@@ -1,0 +1,4 @@
+name: User Types
+description: User Types module
+type: module
+core_version_requirement: ^10

--- a/modules/custom/user_types/user_types.routing.yml
+++ b/modules/custom/user_types/user_types.routing.yml
@@ -1,0 +1,10 @@
+user_types.board_members:
+  path: '/board-member'
+  defaults:
+    _controller: '\Drupal\user_types\Controller\UserTypesController::boardMember'
+    _title: 'Board member'
+  requirements:
+    _user_types_access_check: 'TRUE'
+  options:
+    _user_types:
+      - board_member

--- a/modules/custom/user_types/user_types.routing.yml
+++ b/modules/custom/user_types/user_types.routing.yml
@@ -8,3 +8,38 @@ user_types.board_members:
   options:
     _user_types:
       - board_member
+
+user_types.manager:
+  path: '/manager'
+  defaults:
+    _controller: '\Drupal\user_types\Controller\UserTypesController::manager'
+    _title: 'Manager'
+  requirements:
+    _user_types_access_check: 'TRUE'
+  options:
+    _user_types:
+      - manager
+
+user_types.employee:
+  path: '/employee'
+  defaults:
+    _controller: '\Drupal\user_types\Controller\UserTypesController::employee'
+    _title: 'Employee'
+  requirements:
+    _user_types_access_check: 'TRUE'
+  options:
+    _user_types:
+      - manager
+      - employee
+
+user_types.leadership:
+  path: '/leadership'
+  defaults:
+    _controller: '\Drupal\user_types\Controller\UserTypesController::leadership'
+    _title: 'Leadership'
+  requirements:
+    _user_types_access_check: 'TRUE'
+  options:
+    _user_types:
+      - board_member
+      - manager


### PR DESCRIPTION
**Scenario:** We need to have 'user_roles' and given them the access to nodes based on the access they have.

We have solved the above scenario by having following:

- Created 'user_types' module
- defined routing file to for every user_role & mapped them to their associated Controller file.
- defined custom service file to check the access of the each user_role in 'UserTypesAccess.php' class
- defined custom hooks in module file to enhance the access checks